### PR TITLE
graphql: add support for aliases

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,5 @@
 use crate::error;
+use crate::types;
 use postgres::{Client, NoTls, Row};
 
 pub fn get_pg_client(connection_string: String) -> Client {
@@ -12,13 +13,23 @@ pub fn get_pg_client(connection_string: String) -> Client {
     }
 }
 
-pub fn get_rows_gql_query(client: &mut Client, root_field: &str, fields: &Vec<String>) -> Row {
+pub fn get_rows_gql_query(
+    client: &mut Client,
+    root_field: &types::FieldName,
+    fields: &[types::FieldName],
+) -> Result<Row, postgres::error::Error> {
     let mut query = String::new();
     // NOTE: since we're using json_agg here, the DB has to be of v9 or over
-    query.push_str(format!("SELECT json_agg(data) AS {} FROM (SELECT ", root_field).as_str());
+    query.push_str(
+        format!(
+            "SELECT json_agg(data) AS {} FROM (SELECT ",
+            root_field.alias()
+        )
+        .as_str(),
+    );
 
     for field_name in fields.iter() {
-        query.push_str(format!("\"{}\", ", field_name).as_str());
+        query.push_str(format!("{}, ", field_name.to_sql()).as_str());
     }
 
     // remove the extra (", ")
@@ -26,14 +37,9 @@ pub fn get_rows_gql_query(client: &mut Client, root_field: &str, fields: &Vec<St
     query.pop();
 
     // FIXME?: support other schemas based on the info that might be stored in metadata
-    query.push_str(format!(" FROM \"public\".\"{}\") as data", root_field).as_str());
+    query.push_str(format!(" FROM \"public\".\"{}\") as data", root_field.name()).as_str());
 
     // ----- Query construction ends
 
-    let query_result = client.query_one(query.as_str(), &[]);
-    match query_result {
-        Ok(result) => return result,
-        // FIXME?: This may not be the best strategy
-        Err(e) => panic!("Failed to fetch information from data source: {}", e),
-    }
+    client.query_one(query.as_str(), &[])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ async fn main() -> std::io::Result<()> {
     actix_web::HttpServer::new(move || {
         actix_web::App::new()
             // TODO: eventually, this would be the server ctx
-            .data(connection_string.clone())
+            .data(<&str>::clone(&connection_string))
             .wrap(actix_web::middleware::Logger::default())
             .wrap(
                 actix_cors::Cors::default()

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,7 +5,7 @@ use clap::Clap;
     name = "graphql-engine-rs",
     about = "An (UNOFFICIAL) implementation of the Hasura GraphQL Engine using rust",
     version = "0.1.0",
-    author = "Sameer Kolhar <sameer@hasura.io>"
+    author = "Sameer Kolhar <kolhar.sam@gmail.com>"
 )]
 pub struct Options {
     #[clap(
@@ -17,13 +17,6 @@ pub struct Options {
     pub source_name: String,
     #[clap(short, long, about = "the connection string to a PG data source")]
     pub connection_string: String,
-    // TODO: consider to put this in later, maybe not just yet
-    // #[clap(
-    //     long,
-    //     default_value = "[\"public\"]",
-    //     about = "the schema(s) that should be scanned to generate the GraphQL schema"
-    // )]
-    // pub schemas: Vec<String>,
     #[clap(short, long, about = "server port", default_value = "3000")]
     pub port: u16,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -164,7 +164,7 @@ fn fetch_result_from_selection_set<'a>(
 
     for set_item in sel_set.items.iter() {
         if let graphql_parser::query::Selection::Field(fld) = set_item {
-            let alias: Option<String> = utils::optional_fmap(fld.alias, |&s| s.to_string());
+           let alias = fld.alias.map(String::from);
             let root_field_name = FieldName::new(fld.name, alias);
             fields_map.insert(
                 root_field_name,

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,7 +90,7 @@ fn fetch_result_from_query_fields<'a>(
         if let graphql_parser::query::Selection::Field(field) = set {
             // FIXME: make this recursive too, this is just one level now...
             let table_name = field.name.to_string();
-            let alias: Option<String> = utils::optional_fmap(field.alias, |&s| s.to_string());
+            let alias = field.alias.map(String::from);
             let root_field_name = FieldName::new(&table_name, alias);
             fields_map.insert(
                 root_field_name,

--- a/src/server.rs
+++ b/src/server.rs
@@ -148,7 +148,7 @@ fn selection_set_fields_parser<'a>(
 
     for set_item in sel_set.items.iter() {
         if let graphql_parser::query::Selection::Field(fld) = set_item {
-            let alias: Option<String> = utils::optional_fmap(fld.alias, |&s| s.to_string());
+            let alias = fld.alias.map(String::from);
             fields.push(FieldName::new(fld.name, alias));
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use crate::db;
 use crate::error;
 use crate::types::{FieldName, QualifiedTable};
-use crate::utils;
 
 pub async fn healthz_handler(_req: actix_web::HttpRequest) -> String {
     // actix_web::HttpResponse::Ok().json(json!({"Ok": true}))
@@ -164,7 +163,7 @@ fn fetch_result_from_selection_set<'a>(
 
     for set_item in sel_set.items.iter() {
         if let graphql_parser::query::Selection::Field(fld) = set_item {
-           let alias = fld.alias.map(String::from);
+            let alias = fld.alias.map(String::from);
             let root_field_name = FieldName::new(fld.name, alias);
             fields_map.insert(
                 root_field_name,

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 // use crate::context;
 use crate::db;
 use crate::error;
-use crate::types;
+use crate::types::{FieldName, QualifiedTable};
+use crate::utils;
 
 pub async fn healthz_handler(_req: actix_web::HttpRequest) -> String {
     // actix_web::HttpResponse::Ok().json(json!({"Ok": true}))
@@ -17,8 +18,8 @@ pub async fn healthz_handler(_req: actix_web::HttpRequest) -> String {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", content = "args", rename_all = "snake_case")]
 pub enum MetadataMessage {
-    TrackTable(types::QualifiedTable),
-    UntrackTable(types::QualifiedTable),
+    TrackTable(QualifiedTable),
+    UntrackTable(QualifiedTable),
     // NOTE: args will only be `null` in this case
     ExportMetadata,
 }
@@ -77,35 +78,64 @@ pub struct GraphQLRequest {
     variables: indexmap::IndexMap<String, String>,
 }
 
+type GQLResult = indexmap::IndexMap<String, serde_json::Value>;
+
 fn fetch_result_from_query_fields<'a>(
     qry: &graphql_parser::query::Query<'a, &'a str>,
     client: &mut Client,
 ) -> actix_web::HttpResponse {
-    let mut fields_map: indexmap::IndexMap<String, Vec<String>> = indexmap::IndexMap::new();
-    let mut query_fields: Vec<String> = Vec::new();
+    let mut fields_map: indexmap::IndexMap<FieldName, Vec<FieldName>> = indexmap::IndexMap::new();
 
     for set in qry.selection_set.items.iter() {
         if let graphql_parser::query::Selection::Field(field) = set {
             // FIXME: make this recursive too, this is just one level now...
             let table_name = field.name.to_string();
-            query_fields.append(&mut selection_set_fields_parser(&field.selection_set));
-            fields_map.insert(table_name, query_fields.clone());
+            let alias: Option<String> = utils::optional_fmap(field.alias, |&s| s.to_string());
+            let root_field_name = FieldName::new(&table_name, alias);
+            fields_map.insert(
+                root_field_name,
+                selection_set_fields_parser(&field.selection_set),
+            );
         }
     }
 
     let mut result_rows: Vec<Row> = Vec::new();
     for field_info in fields_map.iter() {
-        result_rows.push(db::get_rows_gql_query(client, field_info.0, field_info.1));
+        let query_res = db::get_rows_gql_query(client, field_info.0, field_info.1);
+        match query_res {
+            Ok(db_res) => {
+                result_rows.push(db_res);
+            }
+            // NOTE: this error is encounted when the query fails at the DB
+            Err(db_err) => {
+                return actix_web::HttpResponse::Ok().json(ErrorResponse {
+                    error: db_err.to_string(),
+                })
+            }
+        }
     }
 
-    let mut final_res: indexmap::IndexMap<String, serde_json::Value> = indexmap::IndexMap::new();
+    let mut final_res: GQLResult = indexmap::IndexMap::new();
 
     for res_row in result_rows.iter() {
+        // FIXME: can be a potential point of failure
         let root_field_name = res_row.columns()[0].name();
-        let query_result: Json<serde_json::Value> = res_row.get(root_field_name.clone());
-        final_res.insert(root_field_name.to_string(), query_result.0);
-        // TODO: remove this after adding some tests
-        // final_res.insert(root_field_name.to_string(), utils::remap_json(query_result.0, &query_fields));
+        let query_result: Result<Json<serde_json::Value>, postgres::Error> =
+            res_row.try_get(root_field_name);
+        match query_result {
+            Ok(result) => {
+                final_res.insert(root_field_name.to_string(), result.0);
+            }
+            // NOTE: this error is reported when we encounter no rows or nulls
+            Err(_err) => {
+                // NOTE: this is not consistent with Hasura's behavior, in Hasura,
+                // all of the columns in the query are placed with a `null`
+                final_res.insert(
+                    root_field_name.to_string(),
+                    serde_json::json!({ root_field_name.to_string(): serde_json::Value::Null }),
+                );
+            }
+        }
     }
 
     actix_web::HttpResponse::Ok().json(DataResponse { data: final_res })
@@ -113,13 +143,13 @@ fn fetch_result_from_query_fields<'a>(
 
 fn selection_set_fields_parser<'a>(
     sel_set: &graphql_parser::query::SelectionSet<'a, &'a str>,
-) -> Vec<String> {
-    let mut fields: Vec<String> = Vec::new();
+) -> Vec<FieldName> {
+    let mut fields: Vec<FieldName> = Vec::new();
 
-    // TODO: aliases are also not supported
     for set_item in sel_set.items.iter() {
         if let graphql_parser::query::Selection::Field(fld) = set_item {
-            fields.push(fld.name.to_string());
+            let alias: Option<String> = utils::optional_fmap(fld.alias, |&s| s.to_string());
+            fields.push(FieldName::new(fld.name, alias));
         }
     }
 
@@ -130,24 +160,27 @@ fn fetch_result_from_selection_set<'a>(
     sel_set: &graphql_parser::query::SelectionSet<'a, &'a str>,
     _client: &mut Client,
 ) -> actix_web::HttpResponse {
-    let mut fields_map: indexmap::IndexMap<String, Vec<String>> = indexmap::IndexMap::new();
+    let mut fields_map: indexmap::IndexMap<FieldName, Vec<FieldName>> = indexmap::IndexMap::new();
 
     for set_item in sel_set.items.iter() {
         if let graphql_parser::query::Selection::Field(fld) = set_item {
+            let alias: Option<String> = utils::optional_fmap(fld.alias, |&s| s.to_string());
+            let root_field_name = FieldName::new(fld.name, alias);
             fields_map.insert(
-                fld.name.to_string(),
+                root_field_name,
                 selection_set_fields_parser(&fld.selection_set),
             );
         }
     }
 
+    // TODO: this shouldn't be here anymore :P
     actix_web::HttpResponse::Ok().json(ErrorResponse {
         error: format!("{:?}", fields_map),
     })
 }
 
-// NOTE: this is only for Query, Selection sets Mutation(which are currently not supported)
-//       will have to implement something different for Subscriptions.
+// NOTE: Only GraphQL Queries and Selection Sets are supported.
+//       Mutations, Subscriptions will be supported eventually.
 pub async fn graphql_handler(
     srv_ctx: actix_web::web::Data<&'static str>,
     payload: actix_web::web::Bytes,
@@ -164,64 +197,46 @@ pub async fn graphql_handler(
     };
 
     match serde_json::from_str::<'_, GraphQLRequest>(&body.dump()) {
-        Ok(b) => {
-            match graphql_parser::parse_query::<&str>(&b.query) {
-                Ok(q) => {
-                    for i in q.definitions.iter() {
-                        match i {
-                            graphql_parser::query::Definition::Fragment(_) => {
-                                return actix_web::HttpResponse::Ok().json(ErrorResponse {
-                                    error: error::GQLRSError {
-                                        kind: error::GQLRSErrorType::GenericError(
-                                            "Fragments are not yet supported!".to_string(),
-                                        ),
-                                    }
-                                    .to_string(),
-                                })
-                            }
-                            graphql_parser::query::Definition::Operation(op) => match op {
-                                graphql_parser::query::OperationDefinition::Mutation(_) => {
-                                    return actix_web::HttpResponse::Ok().json(ErrorResponse {
-                                        error: error::GQLRSError {
-                                            kind: error::GQLRSErrorType::GenericError(
-                                                "Mutations are not yet supported!".to_string(),
-                                            ),
-                                        }
-                                        .to_string(),
-                                    })
-                                }
-                                graphql_parser::query::OperationDefinition::Subscription(_) => {
-                                    return actix_web::HttpResponse::Ok().json(ErrorResponse {
-                                        error: error::GQLRSError {
-                                            kind: error::GQLRSErrorType::GenericError(
-                                                "Subscriptions are not yet supported!".to_string(),
-                                            ),
-                                        }
-                                        .to_string(),
-                                    })
-                                }
-                                graphql_parser::query::OperationDefinition::Query(qry) => {
-                                    return fetch_result_from_query_fields(qry, &mut pg_client)
-                                }
-                                graphql_parser::query::OperationDefinition::SelectionSet(
-                                    sel_set,
-                                ) => {
-                                    return fetch_result_from_selection_set(sel_set, &mut pg_client)
-                                }
-                            },
-                        }
+        Ok(b) => match graphql_parser::parse_query::<&str>(&b.query) {
+            // NOTE: We only execute the first query/mutation/subscription that
+            // gets matched/parsed. Similar to what Hasura does
+            Ok(q) => match &q.definitions[0] {
+                graphql_parser::query::Definition::Fragment(_) => actix_web::HttpResponse::Ok()
+                    .json(ErrorResponse {
+                        error: error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+                            "Fragments are not yet supported!".to_string(),
+                        ))
+                        .to_string(),
+                    }),
+                graphql_parser::query::Definition::Operation(op) => match op {
+                    graphql_parser::query::OperationDefinition::Mutation(_) => {
+                        actix_web::HttpResponse::Ok().json(ErrorResponse {
+                            error: error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+                                "Mutations are not yet supported!".to_string(),
+                            ))
+                            .to_string(),
+                        })
                     }
-                }
-                Err(e) => {
-                    return actix_web::HttpResponse::Ok().json(ErrorResponse {
-                        error: e.to_string(),
-                    })
-                }
-            }
-            actix_web::HttpResponse::Ok().json(error::GQLRSError {
-                kind: error::GQLRSErrorType::GenericError("Unsolicited error".to_string()),
-            })
-        }
+                    graphql_parser::query::OperationDefinition::Subscription(_) => {
+                        actix_web::HttpResponse::Ok().json(ErrorResponse {
+                            error: error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+                                "Subscriptions are not yet supported!".to_string(),
+                            ))
+                            .to_string(),
+                        })
+                    }
+                    graphql_parser::query::OperationDefinition::Query(qry) => {
+                        fetch_result_from_query_fields(qry, &mut pg_client)
+                    }
+                    graphql_parser::query::OperationDefinition::SelectionSet(sel_set) => {
+                        fetch_result_from_selection_set(sel_set, &mut pg_client)
+                    }
+                },
+            },
+            Err(e) => actix_web::HttpResponse::Ok().json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        },
         Err(e) => actix_web::HttpResponse::Ok().json(ErrorResponse {
             error: e.to_string(),
         }),

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,3 +88,52 @@ impl Metadata {
         Ok(())
     }
 }
+
+// FieldName is a type exclusively for GraphQL
+#[derive(Debug, Serialize, Clone, PartialEq, Eq, std::hash::Hash)]
+pub struct FieldName(
+    Option<String>, // this is for any alias
+    String,         // this is the actual field name
+);
+
+impl FieldName {
+    pub fn new(field_name: &str, field_alias: Option<String>) -> FieldName {
+        FieldName(field_alias, field_name.to_string())
+    }
+
+    pub fn to_sql(&self) -> String {
+        let mut alias = String::from(&self.1);
+        if let Some(a) = self.0.clone() {
+            alias = a;
+        }
+
+        format!("{} AS {}", utils::dquote(self.1.as_str()), alias)
+    }
+
+    pub fn name(&self) -> String {
+        self.1.clone()
+    }
+
+    pub fn alias(&self) -> String {
+        if let Some(alias) = self.0.clone() {
+            return alias;
+        }
+
+        self.1.clone()
+    }
+}
+
+#[test]
+fn field_name_to_sql_with_no_alias() {
+    let new_field_name = FieldName::new("users", None);
+    assert_eq!(new_field_name.to_sql(), "\"users\" AS users".to_string());
+}
+
+#[test]
+fn field_name_to_sql_with_alias() {
+    let new_field_name = FieldName::new("users", Some("new_users".to_string()));
+    assert_eq!(
+        new_field_name.to_sql(),
+        "\"users\" AS new_users".to_string()
+    );
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,10 +24,3 @@ pub fn to_lower_case(s: &str) -> String {
 pub fn string_to_static_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
-
-pub fn optional_fmap<T, U>(op: Option<T>, map_fn: fn(&T) -> U) -> Option<U> {
-    if let Some(t) = op {
-        return Some(map_fn(&t));
-    }
-    None
-}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,44 +25,9 @@ pub fn string_to_static_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
 
-// NOTE: This is a bit of a hack, but it's the only way I could get the order 
-// of the keys to match that of the query
-pub fn remap_json(current_json: serde_json::Value, key_order: &Vec<String>) -> serde_json::Value {
-    if current_json.is_object() {
-        let mut new_json: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-
-        for key in key_order.iter() {
-            match current_json.get(key) {
-                Some(v) => {
-                    new_json.insert(key.to_string(), v.clone());
-                },
-                None => {},
-            }
-        }
-
-        return serde_json::Value::Object(new_json);
-    } else if current_json.is_array() {
-        let mut new_json_arr: Vec<serde_json::Value> = Vec::new();
-
-        // NOTE: watch out for the unwrap here
-        let current_json_vec: Vec<serde_json::Value> = serde_json::from_value(current_json).unwrap();
-
-        for current_obj in current_json_vec.iter() {
-            let mut new_obj: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-            for key in key_order.iter() {
-                match current_obj.get(key) {
-                    Some(v) => {
-                        new_obj.insert(key.to_string(), v.clone());
-                    },
-                    None => {},
-                }
-            }
-            new_json_arr.push(serde_json::Value::Object(new_obj));
-        }
-
-        return serde_json::Value::Array(new_json_arr);
+pub fn optional_fmap<T, U>(op: Option<T>, map_fn: fn(&T) -> U) -> Option<U> {
+    if let Some(t) = op {
+        return Some(map_fn(&t));
     }
-
-    // NOTE: worst case scenario, ideally we shouldn't get here
-    serde_json::Value::Null
+    None
 }


### PR DESCRIPTION
this PR should resolve #5 

there's some clean up done on the PR to ensure that we process only 1 query root ONLY, since this is what happens on the hasura too. 