### PR TITLE
graphql: support simple arguments like `offset`, `limit` and `distinct_on`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -92,10 +92,6 @@ pub fn get_rows_gql_query(
 
     let query_result = client.query_one(query.as_str(), &[]);
 
-    match query_result {
-        Ok(res) => Ok(res),
-        Err(err) => Err(error::GQLRSError::new(error::GQLRSErrorType::DBError(
-            format!("{:?}", err),
-        ))),
-    }
+    query_result
+        .map_err(|err| error::GQLRSError::new(error::GQLRSErrorType::DBError(format!("{:?}", err))))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,9 +6,11 @@ pub fn get_pg_client(connection_string: String) -> Client {
     let client = Client::connect(&connection_string, NoTls);
     match client {
         Ok(c) => c,
+        // NOTE: Panic-ing since this is a crisis, the DB is out,
+        // should move to a more safe handling of this sooner than later
         Err(e) => panic!(
             "{}",
-            error::GQLRSError::new(error::GQLRSErrorType::DBConnectionError(e.to_string()),)
+            error::GQLRSError::new(error::GQLRSErrorType::DBError(e.to_string()))
         ),
     }
 }
@@ -16,19 +18,38 @@ pub fn get_pg_client(connection_string: String) -> Client {
 pub fn get_rows_gql_query(
     client: &mut Client,
     root_field: &types::FieldName,
-    fields: &[types::FieldName],
-) -> Result<Row, postgres::error::Error> {
+    field_info: &types::FieldInfo,
+) -> Result<Row, error::GQLRSError> {
     let mut query = String::new();
+    let query_has_args = !field_info.root_field_arguments.is_empty();
+
     // NOTE: since we're using json_agg here, the DB has to be of v9 or over
     query.push_str(
         format!(
-            "SELECT json_agg(data) AS {} FROM (SELECT ",
+            "SELECT coalesce(json_agg(data), '[]') AS {} FROM (SELECT ",
             root_field.alias()
         )
         .as_str(),
     );
 
-    for field_name in fields.iter() {
+    // add the distinct on clause (if necessary)
+    if query_has_args && field_info.root_field_arguments.contains_key("distinct_on") {
+        let distinct_col = field_info.root_field_arguments.get("distinct_on");
+        match distinct_col {
+            Some(val) => {
+                query.push_str(format!("DISTINCT ON({}) ", val.get_string()).as_str());
+            }
+            None => {
+                // NOTE: this case would be highly unlikely since we're checking whether
+                // the key is present at all in the first place
+                return Err(error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+                    "argument value not found".to_string(),
+                )));
+            }
+        }
+    }
+
+    for field_name in field_info.fields.iter() {
         query.push_str(format!("{}, ", field_name.to_sql()).as_str());
     }
 
@@ -36,10 +57,45 @@ pub fn get_rows_gql_query(
     query.pop();
     query.pop();
 
-    // FIXME?: support other schemas based on the info that might be stored in metadata
-    query.push_str(format!(" FROM \"public\".\"{}\") as data", root_field.name()).as_str());
+    // FIXME/TODO: support other schemas based on the info that might be stored in metadata
+    query.push_str(format!(" FROM \"public\".\"{}\" ", root_field.name()).as_str());
+
+    if query_has_args {
+        for field_arg in types::SUPPORTED_INT_GQL_ARGUMENTS.iter() {
+            if (*field_arg) == "limit" {
+                let arg_val = field_info.root_field_arguments.get("limit");
+                match arg_val {
+                    None => {}
+                    Some(val) => {
+                        query.push_str(format!("LIMIT {} ", val.get_num()).as_str());
+                    }
+                }
+            }
+
+            if (*field_arg) == "offset" {
+                let arg_val = field_info.root_field_arguments.get("offset");
+                match arg_val {
+                    None => {}
+                    Some(val) => {
+                        query.push_str(format!("OFFSET {} ", val.get_num()).as_str());
+                    }
+                }
+            }
+        }
+    }
+
+    query.push_str(") as data");
 
     // ----- Query construction ends
 
-    client.query_one(query.as_str(), &[])
+    // ----- Run Query
+
+    let query_result = client.query_one(query.as_str(), &[]);
+
+    match query_result {
+        Ok(res) => Ok(res),
+        Err(err) => Err(error::GQLRSError::new(error::GQLRSErrorType::DBError(
+            format!("{:?}", err),
+        ))),
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ pub enum GQLRSErrorType {
     #[error("ERROR: Table {0} not found in metadata")]
     TableNotFoundInMetadata(String),
     #[error("Error: failed to connect with database at {0}")]
-    DBConnectionError(String),
+    DBError(String),
     #[error("ERROR: Invalid input was supplied.")]
     InvalidInput,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,14 @@
+use indexmap::IndexMap;
 use postgres::types::Json;
 use postgres::{Client, Row};
 use serde::{Deserialize, Serialize};
 
 use crate::db;
 use crate::error;
-use crate::types::{FieldName, QualifiedTable};
+use crate::types::{
+    field_names_to_name_list, to_int_arg, to_string_arg, FieldInfo, FieldName, GQLArgType,
+    QualifiedTable, SUPPORTED_INT_GQL_ARGUMENTS, SUPPORTED_STRING_GQL_ARGUMENTS,
+};
 
 pub async fn healthz_handler(_req: actix_web::HttpRequest) -> String {
     "OK".to_string()
@@ -34,7 +38,7 @@ pub struct ErrorResponse {
 // NOTE: this should be used for sending the API response
 #[derive(Serialize, Debug, Clone)]
 pub struct DataResponse {
-    data: indexmap::IndexMap<String, serde_json::Value>,
+    data: IndexMap<String, serde_json::Value>,
 }
 
 pub async fn metadata_handler(payload: actix_web::web::Bytes) -> actix_web::HttpResponse {
@@ -54,7 +58,7 @@ pub async fn metadata_handler(payload: actix_web::web::Bytes) -> actix_web::Http
             .content_type("application/json")
             .body(
                 serde_json::to_string(&b)
-                    .unwrap_or("Failed to convert body to a valid string".to_string()),
+                    .unwrap_or_else(|_| "Failed to convert body to a valid string".to_string()),
             ),
         Err(e) => actix_web::HttpResponse::build(actix_web::http::StatusCode::BAD_REQUEST).json(
             ErrorResponse {
@@ -69,18 +73,18 @@ pub async fn metadata_handler(payload: actix_web::web::Bytes) -> actix_web::Http
     // })
 }
 
-fn empty_query_variables() -> indexmap::IndexMap<String, String> {
-    indexmap::IndexMap::new()
+fn empty_query_variables() -> IndexMap<String, String> {
+    IndexMap::new()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GraphQLRequest {
     query: String,
     #[serde(default = "empty_query_variables")]
-    variables: indexmap::IndexMap<String, String>,
+    variables: IndexMap<String, String>,
 }
 
-type GQLResult = indexmap::IndexMap<String, serde_json::Value>;
+type GQLResult = IndexMap<String, serde_json::Value>;
 
 fn fetch_result_from_query_fields<'a>(
     qry_sel_set: &graphql_parser::query::SelectionSet<'a, &'a str>,
@@ -89,27 +93,61 @@ fn fetch_result_from_query_fields<'a>(
     // many of the patterns, like Query, Selection Set and eventually Subscriptions!
     pg_client: &mut Client,
 ) -> actix_web::HttpResponse {
-    let mut fields_map: indexmap::IndexMap<FieldName, Vec<FieldName>> = indexmap::IndexMap::new();
+    let mut fields_map: IndexMap<FieldName, FieldInfo> = IndexMap::new();
 
     for set in qry_sel_set.items.iter() {
+        // NOTE: Nothing's being done for the other variants of the Selection enum
         if let graphql_parser::query::Selection::Field(field) = set {
             // FIXME: make this recursive too, this is just one level now...
             let table_name = field.name.to_string();
             let alias = field.alias.map(String::from);
             let root_field_name = FieldName::new(&table_name, alias);
-            fields_map.insert(
-                root_field_name,
-                selection_set_fields_parser(&field.selection_set),
-            );
+            let mut field_args: IndexMap<String, GQLArgType> = IndexMap::new();
+            let sub_fields = selection_set_fields_parser(&field.selection_set);
+
+            if !field.arguments.is_empty() {
+                for root_field_arg in field.arguments.iter() {
+                    let arg_name = root_field_arg.0.to_string();
+                    let arg_value = &root_field_arg.1;
+                    if SUPPORTED_STRING_GQL_ARGUMENTS.contains(&arg_name.as_str()) {
+                        let convert_to_string_arg = to_string_arg(arg_name, arg_value);
+                        if let Ok(fa) = convert_to_string_arg {
+                            let str_fields = field_names_to_name_list(&sub_fields);
+                            if str_fields.contains(&fa.1.get_string()) {
+                                field_args.insert(fa.0, fa.1);
+                            } else {
+                                return actix_web::HttpResponse::Ok().json(ErrorResponse {
+                                    error: format!("The value should be one of: {:?}", str_fields),
+                                });
+                            }
+                        } else if let Err(e) = convert_to_string_arg {
+                            return actix_web::HttpResponse::Ok().json(ErrorResponse {
+                                error: e.to_string(),
+                            });
+                        }
+                    } else if SUPPORTED_INT_GQL_ARGUMENTS.contains(&arg_name.as_str()) {
+                        let convert_to_int_arg = to_int_arg(arg_name, arg_value);
+                        if let Ok(fa) = convert_to_int_arg {
+                            field_args.insert(fa.0, fa.1);
+                        } else if let Err(e) = convert_to_int_arg {
+                            return actix_web::HttpResponse::Ok().json(ErrorResponse {
+                                error: e.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            fields_map.insert(root_field_name, FieldInfo::new(sub_fields, field_args));
         }
     }
 
     let mut result_rows: Vec<Row> = Vec::new();
     for field_info in fields_map.iter() {
         let root_field_name = field_info.0;
-        let fields = field_info.1;
+        let fields_info_struct = field_info.1;
 
-        let query_res = db::get_rows_gql_query(pg_client, root_field_name, fields);
+        let query_res = db::get_rows_gql_query(pg_client, root_field_name, fields_info_struct);
         match query_res {
             Ok(db_res) => {
                 result_rows.push(db_res);
@@ -123,7 +161,7 @@ fn fetch_result_from_query_fields<'a>(
         }
     }
 
-    let mut final_res: GQLResult = indexmap::IndexMap::new();
+    let mut final_res: GQLResult = IndexMap::new();
 
     for res_row in result_rows.iter() {
         // FIXME: can be a potential point of failure
@@ -136,8 +174,6 @@ fn fetch_result_from_query_fields<'a>(
             }
             // NOTE: this error is reported when we encounter no rows or nulls
             Err(_err) => {
-                // FIXME: this is not consistent with Hasura's behavior, in Hasura,
-                // all of the columns in the query are placed with a `null`
                 final_res.insert(
                     root_field_name.to_string(),
                     serde_json::json!({ root_field_name.to_string(): serde_json::Value::Null }),

--- a/src/server.rs
+++ b/src/server.rs
@@ -48,10 +48,7 @@ pub async fn metadata_handler(payload: actix_web::web::Bytes) -> actix_web::Http
         Err(_err) => Err(json::Error::FailedUtf8Parsing),
     };
 
-    let body: json::JsonValue = match parse_result {
-        Ok(v) => v,
-        Err(e) => json::object! { "error" => e.to_string() },
-    };
+    let body = parse_result.unwrap_or_else(|e| json::object! { "error" => e.to_string() });
 
     match serde_json::from_str::<'_, MetadataMessage>(&body.dump()) {
         Ok(b) => actix_web::HttpResponse::Ok()
@@ -216,10 +213,7 @@ pub async fn graphql_handler(
         Err(_err) => Err(json::Error::FailedUtf8Parsing),
     };
 
-    let body: json::JsonValue = match parse_result {
-        Ok(v) => v,
-        Err(e) => json::object! { "error" => e.to_string() },
-    };
+    let body = parse_result.unwrap_or_else(|e| json::object! { "error" => e.to_string() });
 
     match serde_json::from_str::<'_, GraphQLRequest>(&body.dump()) {
         Ok(b) => match graphql_parser::parse_query::<&str>(&b.query) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -107,7 +107,11 @@ impl FieldName {
             alias = a;
         }
 
-        format!("{} AS {}", utils::dquote(self.1.as_str()), alias)
+        format!(
+            "{} AS {}",
+            utils::dquote(self.1.as_str()),
+            utils::dquote(&alias)
+        )
     }
 
     pub fn name(&self) -> String {
@@ -116,10 +120,10 @@ impl FieldName {
 
     pub fn alias(&self) -> String {
         if let Some(alias) = self.0.clone() {
-            return alias;
+            return utils::dquote(&alias);
         }
 
-        self.1.clone()
+        utils::dquote(&self.1)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,7 +141,7 @@ pub fn field_names_to_name_list(nl: &[FieldName]) -> Vec<String> {
 #[test]
 fn field_name_to_sql_with_no_alias() {
     let new_field_name = FieldName::new("users", None);
-    assert_eq!(new_field_name.to_sql(), "\"users\" AS users".to_string());
+    assert_eq!(new_field_name.to_sql(), "\"users\" AS \"users\"".to_string());
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn field_name_to_sql_with_alias() {
     let new_field_name = FieldName::new("users", Some("new_users".to_string()));
     assert_eq!(
         new_field_name.to_sql(),
-        "\"users\" AS new_users".to_string()
+        "\"users\" AS \"new_users\"".to_string()
     );
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -92,8 +92,8 @@ impl Metadata {
 // FieldName is a type exclusively for GraphQL
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, std::hash::Hash)]
 pub struct FieldName(
-    Option<String>, // this is for any alias
-    String,         // this is the actual field name
+    pub Option<String>, // this is for any alias
+    pub String,         // this is the actual field name
 );
 
 impl FieldName {
@@ -123,6 +123,17 @@ impl FieldName {
     }
 }
 
+// Returns the string values of the `Field` names within a selection set
+pub fn field_names_to_name_list(nl: &[FieldName]) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+
+    for f_name in nl {
+        names.push(f_name.1.clone());
+    }
+
+    names
+}
+
 #[test]
 fn field_name_to_sql_with_no_alias() {
     let new_field_name = FieldName::new("users", None);
@@ -137,3 +148,99 @@ fn field_name_to_sql_with_alias() {
         "\"users\" AS new_users".to_string()
     );
 }
+
+// NOTE: GQLArgs is a simplified version of the
+// AST's representation of arguments. Using
+// such a structure only because it's easier
+// to do operations. The AST is much more
+// sophisticated and hence can become cumbersome
+#[derive(Serialize, Clone, Debug)]
+pub enum GQLArgType {
+    // NOTE: supported for [distinct_on]
+    String(String),
+    // NOTE: supported for [limit, offset]
+    Int(i64),
+    // Float(f32)
+}
+
+type FieldArguments = indexmap::IndexMap<String, GQLArgType>;
+
+impl GQLArgType {
+    // NOTE: functions like the one's defined below
+    // should be limited in usage since we can go
+    // wrong quite easily since we're relying on the
+    // developer's conscience over the type system
+    // hence opening up an avenue for bugs and issues
+
+    pub fn get_num(&self) -> i64 {
+        if let GQLArgType::Int(num) = self {
+            return *num;
+        }
+        // FIXME?: This should/would never happen
+        // unless we use it incorrectly
+        0
+    }
+
+    pub fn get_string(&self) -> String {
+        if let GQLArgType::String(txt) = &self {
+            return txt.to_string();
+        }
+        // FIXME?: This should/would never happen
+        // unless we use it incorrectly
+        "".to_string()
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct FieldInfo {
+    pub fields: Vec<FieldName>,
+    pub root_field_arguments: indexmap::IndexMap<String, GQLArgType>,
+}
+
+impl FieldInfo {
+    pub fn new(fields: Vec<FieldName>, args: FieldArguments) -> FieldInfo {
+        FieldInfo {
+            fields,
+            root_field_arguments: args,
+        }
+    }
+}
+
+pub fn to_string_arg<'a>(
+    arg_name: String,
+    arg_val: &graphql_parser::query::Value<'a, &'a str>,
+) -> Result<(String, GQLArgType), error::GQLRSError> {
+    if let graphql_parser::query::Value::Enum(st) = arg_val {
+        return Ok((arg_name, GQLArgType::String(st.to_string())));
+    }
+
+    Err(error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+        "failed to parse string".to_string(),
+    )))
+}
+
+pub fn to_int_arg<'a>(
+    arg_name: String,
+    arg_val: &graphql_parser::query::Value<'a, &'a str>,
+) -> Result<(String, GQLArgType), error::GQLRSError> {
+    if let graphql_parser::query::Value::Int(num) = arg_val {
+        let inum = num.as_i64();
+        match inum {
+            Some(n) => return Ok((arg_name, GQLArgType::Int(n))),
+            None => {
+                return Err(error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+                    "int is overflown".to_string(),
+                )))
+            }
+        }
+    }
+
+    Err(error::GQLRSError::new(error::GQLRSErrorType::GenericError(
+        "failed to parse int".to_string(),
+    )))
+}
+
+// NOTE: these arguments are case sensitive, in case they're not
+// these exactly we have every right to reject the query!
+pub const SUPPORTED_STRING_GQL_ARGUMENTS: [&str; 1] = ["distinct_on"];
+pub const SUPPORTED_INT_GQL_ARGUMENTS: [&str; 2] = ["offset", "limit"];

--- a/src/types.rs
+++ b/src/types.rs
@@ -215,7 +215,7 @@ pub fn to_string_arg<'a>(
     }
 
     Err(error::GQLRSError::new(error::GQLRSErrorType::GenericError(
-        "failed to parse string".to_string(),
+        format!("failed to parse argument {}", arg_name),
     )))
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,14 +12,6 @@ pub fn to_camel_case(s: &str) -> String {
     s.to_case(Case::Camel)
 }
 
-pub fn to_upper_case(s: &str) -> String {
-    s.to_case(Case::Upper)
-}
-
-pub fn to_lower_case(s: &str) -> String {
-    s.to_case(Case::Lower)
-}
-
 // UNSAFE NOTICE: this option is very unsafe!! use with caution!
 pub fn string_to_static_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())


### PR DESCRIPTION
This PR does some clean-up of the code and resolves #12 and resolves #23 too

To test:
Schema: users(id serial primary key, first_name text, last_name text)

```graphql
{
    limitUsers: users(limit: 2) {
        first_name
        last_name
    }
    distinctUsers: users(distinct_on: last_name) {
        first_name
        last_name
    }
    offsetUsers: users(offset: 3) {
        first_name
        last_name
    }
}
```