### PR TITLE
db: use a connection pool for running queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ json = "0.12"
 indexmap = { version = "1.7.0", features = ["serde", "serde-1"] }
 thiserror = "1.0.26"
 anyhow = "1.0.43"
+r2d2 = "0.8.9"
+r2d2_postgres = "0.18.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,45 +1,44 @@
-use postgres::Client;
+use postgres::NoTls;
+use r2d2::Pool;
+use r2d2_postgres::PostgresConnectionManager;
+use serde::{Deserialize, Serialize};
 
-use crate::types;
-
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum Status {
-    Healthy,
-    Errored,
+    Ok,
+    Error,
 }
 
+type PGPool = Pool<PostgresConnectionManager<NoTls>>;
+
+#[derive(Clone, Debug)]
 pub struct ServerCtx {
-    pub client: Client,
-    pub metadata: types::Metadata,
-    pub status: Status,
+    conn_pool: PGPool,
+    status: Status,
 }
 
 impl ServerCtx {
-    fn new(&self, pg_client: Client, metadata: types::Metadata) -> ServerCtx {
+    pub fn new(pg_pool: PGPool) -> ServerCtx {
         ServerCtx {
-            client: pg_client,
-            metadata,
-            status: Status::Healthy,
+            conn_pool: pg_pool,
+            status: Status::Ok,
         }
     }
 
-    fn get_status(&self) -> Status {
-        self.status
+    pub fn get_status_json(&self) -> serde_json::Value {
+        serde_json::json!({ "status": &self.status })
     }
 
-    fn set_status(&mut self, status: Status) {
-        self.status = status
+    fn set_status_to_errored(&mut self) {
+        self.status = Status::Error
     }
 
-    fn get_metadata(&self) -> &types::Metadata {
-        &self.metadata
+    fn set_status_to_healthy(&mut self) {
+        self.status = Status::Ok
     }
 
-    // fn set_metadata(&mut self, metadata: Metadata)
-    // TODO: -- This is not needed since metadata has all the methods
-    // but something to think about in terms of design
-
-    fn get_client(&self) -> &Client {
-        &self.client
+    pub fn get_connection_pool(&self) -> &PGPool {
+        &self.conn_pool
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,22 +30,15 @@ impl std::fmt::Display for QualifiedTable {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Metadata {
     pub source_name: String,
-    pub connection_string: String,
     pub tables: Vec<QualifiedTable>,
 }
 
 impl Metadata {
-    pub fn new(&self, source_name: String, connection_string: String) -> Metadata {
+    pub fn new(&self, source_name: String) -> Metadata {
         Metadata {
             source_name,
-            connection_string,
             tables: Vec::new(),
         }
-    }
-
-    pub fn update_connection_string(&mut self, connection_string: String) {
-        // TODO: validate connection string?
-        self.connection_string = connection_string;
     }
 
     fn is_table_tracked(&self, qualified_table: &QualifiedTable) -> bool {


### PR DESCRIPTION
resolves #19 

creating a new client for each new request that comes in is expensive and inefficient. this is one of the ways we can make this slightly better.