### PR TITLE
tests: add caching support for assets for tests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,14 @@
+name: Clippy Check
+
+on: push
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,10 @@
-name: Lint & Format check
+name: Lint & Format
 
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   clippy_check:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: |
-        rustup component add clippy
-        rustup component add rustfmt
+      - run: rustup component add clippy && rustup component add rustfmt
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,4 +1,4 @@
-name: Clippy Check
+name: Lint & Format check
 
 on: push
 
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: rustup component add clippy
+      - run: |
+        rustup component add clippy
+        rustup component add rustfmt
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -17,6 +19,10 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+      
+      - uses: mbrobbel/rustfmt-check@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,5 +20,5 @@ jobs:
 
       - uses: actions-rs/clippy-check@v1
         with:
-          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,6 +8,16 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust Build & Test
+name: Build & Test
 
 on:
   push:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
         toolchain: stable
 
     - uses: Swatinem/rust-cache@v1
+      with:
+          cache-on-failure: true
       
     - name: Build project
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,17 +1,21 @@
 name: Rust Build & Test
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [ push, pull_request ]
 
 env:
   CARGO_TERM_COLOR: always
+  DATABASE_URL: postgresql://postgres:postgrespassword@localhost:5432/postgres
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: Swatinem/rust-cache@v1
 
     services:
       postgres:
@@ -37,10 +41,6 @@ jobs:
 
     - name: Setup basic schema on DB
       run: make migrate
-      env:
-        DATABASE_URL: postgresql://postgres:postgrespassword@localhost:5432/postgres
 
     - name: Run tests
       run: make test
-      env:
-        DATABASE_URL: postgresql://postgres:postgrespassword@localhost:5432/postgres

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust Build & Test
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-
-    - uses: Swatinem/rust-cache@v1
-
     services:
       postgres:
         image: postgres:13
@@ -35,6 +28,13 @@ jobs:
     steps:
     - name: Checkout the latest code from branch
       uses: actions/checkout@v2
+    
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: Swatinem/rust-cache@v1
       
     - name: Build project
       run: cargo build --verbose

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # graphql-engine-rs
 
-[![Build](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml)
-
-[![Tests](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml)
+[![Build & Test Workflow badge](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml)
 
 The Hasura GraphQL Engine - in Rust
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # graphql-engine-rs
 
+[![Build](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml)
+
+[![Tests](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/kolharsam/graphql-engine-rs/actions/workflows/rust.yml)
+
 The Hasura GraphQL Engine - in Rust
 
 This is not official. This is just a toy project. 


### PR DESCRIPTION
This PR adds support caching build assets and dependencies to reduce CI times. This PR also adds another workflow to help fix the formatting (as per `cargo fmt` and `cargo clippy`) to help maintain a clean codebase.

Initially, without cache - the tests used to run for about 4 to 5 minutes on average. The changes in this PR help reduce the same to under 2 minutes once the assets are cached per branch / PR.