### PR TITLE
add `kodiak` support

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,8 +4,8 @@ version = 1
 
 [merge]
 require_automerge_label = true
-automerge_label = ["automerge", "🚀 it!"]
-blocking_labels = ["block", "🚫 it!"]
+automerge_label = ["automerge", "🚀"]
+blocking_labels = ["block", "🚫"]
 method = "squash"
 delete_branch_on_merge = true
 

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,8 +4,8 @@ version = 1
 
 [merge]
 require_automerge_label = true
-automerge_label = ["automerge", "🚀"]
-blocking_labels = ["block", "🚫"]
+automerge_label = ["automerge", "🚀!!"]
+blocking_labels = ["block", "🚫!!"]
 method = "squash"
 delete_branch_on_merge = true
 

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,16 @@
+# .kodiak.toml
+
+version = 1
+
+[merge]
+require_automerge_label = true
+automerge_label = ["automerge", "🚀 it!"]
+blocking_labels = ["block", "🚫 it!"]
+method = "squash"
+delete_branch_on_merge = true
+
+[merge.message]
+title = "pull_request_title"
+
+[update]
+always = true


### PR DESCRIPTION
This adds `kodiak` to this repo.

Use `automerge` or :rocket:!! labels to help automatically merge a PR after the checks are complete on a PR.

Use `block` or :no_entry_sign:!! labels to help block the merge of a PR.